### PR TITLE
Fixing bugs in TOOLSET and LOADTOOL

### DIFF
--- a/PROBECONFIG
+++ b/PROBECONFIG
@@ -5,6 +5,8 @@
 (Initial Coding 1/25/2024: Joshua Smith)
 (macro to setup probe specs and units, called by every macro)
 
+(#20 turns off probe tool number checking : VACANT leaves it on (default); non VACANT turns it off )
+
 (important global variables)
 @100 = -1                        (PROBE TOOL NUMBER, EX: 99)
 
@@ -29,8 +31,8 @@ END_IF
 @112 = 100                       (EXTENDED WORKOFFSET TO STORT TOOLSETTER LOCATION)
 
 #120=R_SYS_INFO[0,2] (CURRENT TOOL NUMBER)
-IF [@100 != #120] (THE PROBE IS NOT LOADED)
-    ALARM["ERROR:  PROTECTED MOVE WITHOUT PROBE - CHANGE TO T#120 "]
+IF [@100 != #120 && #20==#0] (THE PROBE IS NOT LOADED)
+    ALARM["ERROR:  PROTECTED MOVE WITHOUT PROBE - CHANGE TO T#100 "]
 END_IF
 
 M19

--- a/TOOLSET
+++ b/TOOLSET
@@ -6,11 +6,13 @@
 (#2 is the tool angle)
 (#3 is one less than number of test locations)
 
-(load probe config)
-G65 "PROBECONFIG"
-
-
 #100=R_SYS_INFO[0,2]            (SAVE CURRENT TOOL NUMBER TO #100)
+
+
+(load probe config)
+G65 "PROBECONFIG" T#100
+
+
 #104 = @104                     (FAST PROBE SPEED PROVIDED BY PROBECONFIG MACRO)
 #105 = @105                     (SLOW PROBE SPEED PROVIDED BY PROBECONFIG MACRO)
 #110=R_TOOL_DATA[0,199,203]     (TOOLSETTER - T199 - REFERENCE HEIGHT)


### PR DESCRIPTION
fixing a bug in the toolsetting that I introduced when I added probe tool number verification to the tool config. TOOLSET is the one macro that needs to allow non-probe tools