### PR TITLE
fixing a bug in the extended work offsets and updating documentation for probez calibration

### DIFF
--- a/CHECKPOSITIONALTOLERANCE
+++ b/CHECKPOSITIONALTOLERANCE
@@ -16,8 +16,8 @@ G65 "PROBECONFIG"
 
 // CALCULATE EXTENDED WCS NUMBER 
 // FIX is a round down function and MOD is modulo 
-#114 = [[#1 - FIX[#1]] * 10]
-#115 = [[#2 - FIX[#2]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10]
+#115 = ROUND[[#2 - FIX[#2]] * 10]
 
 
  // get WCS ZERO 

--- a/COMPZEROPOINT
+++ b/COMPZEROPOINT
@@ -14,8 +14,8 @@ G65 "PROBECONFIG"
 
 // CALCULATE EXTENDED WCS NUMBER
 // FIX is a round down function and MOD is modulo
-#114 = [[#1 - FIX[#1]] * 10]
-#115 = [[#2 - FIX[#2]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10]
+#115 = ROUND[[#2 - FIX[#2]] * 10]
 
 
  // get WCS ZERO

--- a/COPYWCS
+++ b/COPYWCS
@@ -10,8 +10,8 @@ G65 "PROBECONFIG"
 
 // CALCULATE EXTENDED WCS NUMBER
 // FIX is a round down function and MOD is modulo
-#114 = [[#1 - FIX[#1]] * 10]
-#115 = [[#2 - FIX[#2]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
+#115 = ROUND[[#2 - FIX[#2]] * 10]
 
   // Get Argument B WCS
  IF [ #2 < 53 || #2 == #0]

--- a/FINDCOR
+++ b/FINDCOR
@@ -16,7 +16,7 @@
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 IF[#23==#0] // null check 
     #23 = 1.0 // assume the narrow side of a 123 block

--- a/PROBEX
+++ b/PROBEX
@@ -21,7 +21,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX is a round down function and MOD is modulo
-#114 = MOD[#1,FIX[#1]]*10 
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //Probe X the desired distance and at fast feed
 G31 G91 P2 X[#2] F#111        

--- a/PROBEXSLOT
+++ b/PROBEXSLOT
@@ -27,7 +27,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //probe X starting from a negative offset and probing in the positive direction
 //MOVE TO -X SIDE OF THE PART, BEFORE STARTING TO PROBE

--- a/PROBEXWEB
+++ b/PROBEXWEB
@@ -30,7 +30,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //probe X starting from a negative offset and probing in the positive direction
 //MOVE TO -X SIDE OF THE PART, BEFORE STARTING TO PROBE

--- a/PROBEXYANGLE
+++ b/PROBEXYANGLE
@@ -24,7 +24,7 @@ G65 "PROBECONFIG"
 
 // CALCULATE EXTENDED WCS NUMBER
 // FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 
 IF[#4== 1]

--- a/PROBEY
+++ b/PROBEY
@@ -20,7 +20,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 
 //Probe X the desired distance and at fast feed

--- a/PROBEYSLOT
+++ b/PROBEYSLOT
@@ -27,7 +27,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX is a round down function and MOD is modulo
-#114 = [[#1 - FIX[#1]] * 10] 
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //probe Y starting from a negative offset and probing in the positive direction
 //MOVE TO -Y SIDE OF THE PART, BEFORE STARTING TO PROBE

--- a/PROBEYWEB
+++ b/PROBEYWEB
@@ -29,7 +29,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10] 
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //probe Y starting from a negative offset and probing in the positive direction
 //MOVE TO -Y SIDE OF THE PART, BEFORE STARTING TO PROBE

--- a/PROBEZ
+++ b/PROBEZ
@@ -20,7 +20,7 @@ G65 "PROBECONFIG"
 
 //CALCULATE EXTENDED WCS NUMBER
 //FIX removes any decimal value
-#114 = [[#1 - FIX[#1]] * 10]
+#114 = ROUND[[#1 - FIX[#1]] * 10] 
 
 //Check that the probe distance is negative
 IF[#2<0]


### PR DESCRIPTION
the extended work offsets were missing a round call that is needed because [54.4 - 54] = 0.39999999999999 which gets set down to 3 when used to set an extended work offset. Round fixes this floating point error. 