### PR TITLE
Improvements to the load tool macro

### DIFF
--- a/LOADTOOL
+++ b/LOADTOOL
@@ -4,14 +4,24 @@
 
 // #20 IS THE TOOL NUMBER TO LOAD
 
+// #13 Flag to reset tool offsets then call TOOLSET (defaults off)
+
+// #15 tool number in carousel to swap out (not required) 
+
 // THE TOOL TABLE IS VARIABLES 7000-7011
 
 #120 = 0 // STORES THE OLD TOOL NUMBER
+
+IF[#20 == R_REG[7813]]
+	MSG_OK["Tool In spindle", "T#20 already loaded in the spindle",""]
+	M99
+END_IF
 
 // IF THE TOOL NUMBER IS ALREADY IN THE CAROUSEL WE SWAP THEM
 FOR #100=7000 TO 7011
 	IF[R_REG[#100]==#20]
 		#120 = #20
+		#119 = 0 // Swap tool message flag
 		EXIT_FOR
 	END_IF
 END_FOR
@@ -24,6 +34,8 @@ IF[#120 == 0]
 			#120 = #100
 			// WRITE THE NEW TOOL NUMBER INTO THE TOOL TABLE
 			W_REG[#100, #20]
+			#101 = #100-6999 // store empty tool pocket number
+			#119 = 1 // Swap tool message flag
 			EXIT_FOR
 		END_IF
 	END_FOR
@@ -32,18 +44,25 @@ END_IF
 // IF #120 IS STILL 0 THEN THERE WAS NO EMPTY POCKET
 // AND WE WILL SWAP WITH A DIFFERENT TOOL NUMBER
 IF[#120 == 0]
-	#121 = INPUT["Choose a tool to swap","Tool number?","",1,97,4];
+	#121 = #15 // pull in O argument
+	IF[#121 <= 0]
+		#121 = INPUT["Choose a tool to swap","Choose a tool in the carousel to swap out?","",1,196,13];
+	END_IF
 
 	// CHECK THAT THE TOOL THE USER PICKED IS ACTUALLY IN THE CAROUSEL
 	FOR #100=7000 TO 7011
 		IF[R_REG[#100]==#121]
+			IF[#121 == R_REG[7813]] // check if tool to swap is tool in spindle	
+				W_REG[7813, #20]	// push new tool to tool in spindle to skip tool drop in below M6
+			END_IF
 			// PUSH THE NEW TOOL NUMBER INTO THE TOOL TABLE
 			#120 = #121
 			W_REG[#100, #20]
+			#119 = 2 // Swap tool message flag swap old tool with new
 			EXIT_FOR
 		END_IF
 	END_FOR
-
+	
 	IF[#120 == 0]
 		ALARM["T#121 NOT IN CAROUSEL. CANT SWAP FOR T#20"]
 	END_IF
@@ -55,16 +74,25 @@ END_IF
 // COMMAND A TOOL CHANGE
 T#20 M6
 
-// TELL THE PERSON TO PUT THE TOOL INTO THE SPINDLE
-MSG_OK["INSTALL TOOL", "SWITCH TO MPG MODE AND INSTALL T#20",""]
+// TELL THE PERSON TO PUT THE TOOL INTO THE SPINDLE	
+SELECT[#119]
+	CASE 0:
+		; no message reqired
+	CASE 1:
+		MSG_OK["Install Tool", "Switch to MPG mode and install T#20 in pocket #101",""]
+	CASE 2 :
+		MSG_OK["Swap Tools", "Switch to MPG mode, remove T#121 and swap with T#20",""]
+END_SELECT
 
-// SET THE LENGTH OFFSET TO 999 SO WE CAN'T USE IT WITHOUT TOOLSETTING
-W_TOOL_DATA[0, #20, 203, 999]
-// CLEAR ANY WEAR OFFSETS FOR RADIUS OR LENGTH
-W_TOOL_DATA[0, #20, 2, 0] // RADIAL WEAR
-W_TOOL_DATA[0, #20, 103, 0] // LENGTH WEAR
+IF[#13 == 1]
+	// SET THE LENGTH OFFSET TO 999 SO WE CAN'T USE IT WITHOUT TOOLSETTING
+	W_TOOL_DATA[0, #20, 203, 999]
+	// CLEAR ANY WEAR OFFSETS FOR RADIUS OR LENGTH
+	W_TOOL_DATA[0, #20, 2, 0] // RADIAL WEAR
+	W_TOOL_DATA[0, #20, 103, 0] // LENGTH WEAR
 
-// TOOLSET THE TOOL
-G65 "TOOLSET" A0.0
+	// TOOLSET THE TOOL
+	G65 "TOOLSET" A0.0
+END_IF
 
 M99

--- a/LOADTOOL
+++ b/LOADTOOL
@@ -27,7 +27,7 @@ FOR #100=7000 TO 7011
 END_FOR
 
 // IF NOT ALREADY THERE, THEN FIND AN OPEN POCKET
-IF[#120 == 0]
+IF[#120 == 0 && #15 == #0]
 	// FIND THE FIRST EMPTY POCKET
 	FOR #100=7000 TO 7011
 		IF[R_REG[#100]==199]
@@ -45,7 +45,7 @@ END_IF
 // AND WE WILL SWAP WITH A DIFFERENT TOOL NUMBER
 IF[#120 == 0]
 	#121 = #15 // pull in O argument
-	IF[#121 <= 0]
+	IF[#121 == #0]
 		#121 = INPUT["Choose a tool to swap","Choose a tool in the carousel to swap out?","",1,196,13];
 	END_IF
 
@@ -53,7 +53,7 @@ IF[#120 == 0]
 	FOR #100=7000 TO 7011
 		IF[R_REG[#100]==#121]
 			IF[#121 == R_REG[7813]] // check if tool to swap is tool in spindle	
-				W_REG[7813, #20]	// push new tool to tool in spindle to skip tool drop in below M6
+				W_REG[7813, #20] // push new tool to tool in spindle to skip tool drop in below M6
 			END_IF
 			// PUSH THE NEW TOOL NUMBER INTO THE TOOL TABLE
 			#120 = #121
@@ -69,7 +69,7 @@ IF[#120 == 0]
 END_IF
 
 
-// NOW WERE SURE THAT THE NEW TOOL HAS BEEN PUSHED INTO THE TOOL TABLE
+// NOW WE ARE SURE THAT THE NEW TOOL HAS BEEN PUSHED INTO THE TOOL TABLE
 
 // COMMAND A TOOL CHANGE
 T#20 M6
@@ -77,7 +77,7 @@ T#20 M6
 // TELL THE PERSON TO PUT THE TOOL INTO THE SPINDLE	
 SELECT[#119]
 	CASE 0:
-		; no message reqired
+		; no message is required
 	CASE 1:
 		MSG_OK["Install Tool", "Switch to MPG mode and install T#20 in pocket #101",""]
 	CASE 2 :

--- a/LOADTOOL
+++ b/LOADTOOL
@@ -4,7 +4,7 @@
 
 // #20 IS THE TOOL NUMBER TO LOAD
 
-// #13 Flag to reset tool offsets then call TOOLSET (defaults off)
+// #13 Flag to reset tool offsets then call TOOLSET (not required and defaults on)
 
 // #15 tool number in carousel to swap out (not required) 
 
@@ -58,7 +58,7 @@ IF[#120 == 0]
 			// PUSH THE NEW TOOL NUMBER INTO THE TOOL TABLE
 			#120 = #121
 			W_REG[#100, #20]
-			#119 = 2 // Swap tool message flag swap old tool with new
+			#119 = 2 // Swap tool message flag
 			EXIT_FOR
 		END_IF
 	END_FOR

--- a/README.md
+++ b/README.md
@@ -591,16 +591,16 @@ These macros allow you to add and remove tools without having to manually modify
 Use any tool number you want, up to 198.  
 Tool number 199 is used to signify an empty pocket in the tool table. 
 
-Both the load and unload macros set the tool gauge length to 999 and clear any tool wear compensation values. 
-999 was chosen because its safe. If you don't toolset the tool before use, then you'll get a z-height error when you try to run. 
+Both the load and unload macros have the option to set the tool gauge length to 999 and clear any tool wear compensation values. 
+999 was chosen because it's safe. If you don't toolset the tool before use, then you'll get a z-height error when you try to run. 
 
 ### LOADTOOL
 
-| G Code | "Macro Name" | Macro Argument  |
-| --- | --- | --- |
-| G65 | "LOADTOOL" | T |
+| G Code | "Macro Name" | Macro Argument  | Macro Argument  | Macro Argument  |
+| --- | --- | --- | --- | --- |
+| G65 | "LOADTOOL" | T | O | M |
 
-Example MDI Command: G65 "LOADTOOL" T10
+Example MDI Command: G65 "LOADTOOL" T10 O12
 
 There are three conditions considered: 
 
@@ -608,13 +608,12 @@ There are three conditions considered:
 In this case, call up that tool number and swap in the new tool. 
 
 2) The tool number does not exist in the tool table, and there is an open tool pocket. 
-In this case, assign the new tool to an empty pocket
+In this case, assign the new tool to an empty pocket.
 
 3) The tool number does not exist in the tool table, but there is no empty tool pocket. 
-In this case, prompt the user for which number tool they want to remove. 
-Then re-assign that tool pocket to the new tool number.  
+In this case, prompt the user for which number tool they want to remove if an optional O argument was not sent. Then re-assign that tool pocket to the new tool number. 
 
-After you have loaded the tool, the macro will automatically run the `TOOLSET` macro to set the gauge length. 
+After you have loaded the tool, if no M argument (default) or an M1 argument is used the macro will run the TOOLSET macro to measure the installed tools' gauge length. An M0 argument will cancel the calling of TOOLSET, and skip the measuring of the installed tool allowing the use of the previously measured offsets stored in the tool table.
 
 ### UNLOADTOOL
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# V1.2.1
+- Updated LOADTOOL to with the ability to skip resetting tool offsets and a few minor UI changes
+
 # V1.2.0
 - Added M20 at the end of all probe routines, to unlock spindle so following M19 will actually do something 
 - Improved/corrected COR macro 


### PR DESCRIPTION
- O argument for calling old tool rather than user message
- M argument flag to disable tool reset and measure
- A little work on user messages for extra info specific to each different type of tool drop
- reducing unneeded tool drop-off (swapping the tool in the spindle for a new tool and kicking out if tool is alread loaded in the spindle)